### PR TITLE
Fix for dup nodes in some paged results

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Monarch Knowledge Graph Queries
 Description: R package for easy access, manipulation, and analysis of
 		Monarch KG data Resources.
-Version: 2.1.2
+Version: 2.1.3
 URL: https://github.com/monarch-initiative/monarchr
 BugReports: https://github.com/monarch-initiative/monarchr/issues
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# monarchr 2.1.3
+
+## Bug Fixes
+
+* Fix bug in Cypher paging code resulting in duplicate nodes and edges in some cases.
+
 # monarchr 2.1.2
 
 ## Bug Fixes

--- a/R/kg_join.tbl_kgx.R
+++ b/R/kg_join.tbl_kgx.R
@@ -24,21 +24,29 @@ null_col_entries_to_na <- function(df) {
 #' @import dplyr
 #' @export
 kg_join.tbl_kgx <- function(graph1, graph2, ...) {
-    nodes_g1 <- nodes(graph1)
-    nodes_g2 <- nodes(graph2)
+    nodes_g1 <- null_col_entries_to_na(nodes(graph1))
+    nodes_g2 <- null_col_entries_to_na(nodes(graph2))
 
     # we don't want to keep the to and from columns in the edges, since we'll be rebuilding edges from scratch,
     # and be running them through unique()
-    edges_g1 <- edges(graph1) |> select(-to, -from)
-    edges_g2 <- edges(graph2) |> select(-to, -from)
+    edges_g1 <- null_col_entries_to_na(edges(graph1) |> select(-to, -from))
+    edges_g2 <- null_col_entries_to_na(edges(graph2) |> select(-to, -from))
 
-    all_nodes <- unique(nodes_g1 |>
-                          full_join(nodes_g2)) |>
+    all_nodes <- unique(
+                  null_col_entries_to_na(
+                    nodes_g1 |>
+                      full_join(nodes_g2)
+                  )
+                ) |>
                  mutate(idx = row_number())  # add an index column to the nodes
 
 
-    all_edges <- unique(edges_g1 |>
-                          full_join(edges_g2))
+    all_edges <- unique(
+                  null_col_entries_to_na(
+                    edges_g1 |>
+                      full_join(edges_g2)
+                  )
+                )
 
 
 


### PR DESCRIPTION
Fixes #85; list columns in some paged joins result in NULLs that don't match NA values.